### PR TITLE
Added a very low priority to the "init" action

### DIFF
--- a/pmpro-nav-menus.php
+++ b/pmpro-nav-menus.php
@@ -69,7 +69,7 @@ function register_my_members_menu() {
 		}
 	}
 }
-add_action( 'init', 'register_my_members_menu' );
+add_action( 'init', 'register_my_members_menu', 99 );
 
 function modify_nav_menu_args( $args )
 {


### PR DESCRIPTION
Since plugins load before themes, any theme that registers their plugin on init without a set priority (10) ends up registering after this plugin attempts to duplicate all the menus. Therefore, no menus get duplicated. Setting a low priority of 99 assures that all menus registered on init with a priority lower than 99 wll get duplicated.