### PR TITLE
Changes the priority for when registering a menu

### DIFF
--- a/pmpro-nav-menus.php
+++ b/pmpro-nav-menus.php
@@ -81,7 +81,7 @@ function pmpronm_register_my_members_menu() {
 		}
 	}
 }
-add_action( 'init', 'pmpronm_register_my_members_menu', 99 );
+add_action( 'init', 'pmpronm_register_my_members_menu', 15 );
 
 function pmpronm_modify_nav_menu_args( $args )
 {


### PR DESCRIPTION
We've found that when other plugins or themes loop through menu items, that if we do it too late their changes seem to get lost. 

Running our filter earlier fixes this. 

This was tested with a set up using Astra Pro and Nav Menus, where the menu items had icons added to them. 

Ticket #499924 - Mods Only