### PR TITLE
Updating headings for a11y

### DIFF
--- a/pmpro-nav-menus.php
+++ b/pmpro-nav-menus.php
@@ -35,7 +35,7 @@ function pmpronm_pmpro_membership_level_after_other_settings()
 	else
 		$pmpro_nav_menu = false;
 ?>
-<h3 class="topborder"><?php esc_html_e( 'Navigation Menu', 'pmpro-nav-menus' ); ?></h3>
+<h2 class="topborder"><?php esc_html_e( 'Navigation Menu', 'pmpro-nav-menus' ); ?></h2>
 <table>
 <tbody class="form-table">
 	<tr>


### PR DESCRIPTION
PMPro v2.11 updated the checkout page headings hierarchy from h3 to h2. This PR updates this Add On to follow the same pattern for accessibility.